### PR TITLE
fix: resolve CLIP fallback device mismatch and improve Qwen

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Environment check script for Multi-Vision Toolkit
+This script helps diagnose dependency issues and environment setup problems.
+"""
+
+import sys
+import os
+
+def check_python_version():
+    """Check Python version compatibility."""
+    print(f"Python version: {sys.version}")
+    if sys.version_info < (3, 9):
+        print("❌ Python 3.9+ is required")
+        return False
+    else:
+        print("✅ Python version is compatible")
+        return True
+
+def check_conda_env():
+    """Check if we're in the right conda environment."""
+    conda_env = os.environ.get('CONDA_DEFAULT_ENV', 'None')
+    print(f"Current conda environment: {conda_env}")
+    if conda_env == 'vision-env':
+        print("✅ Running in vision-env environment")
+        return True
+    elif conda_env == 'base':
+        print("❌ Running in base environment. Please activate vision-env:")
+        print("   conda activate vision-env")
+        return False
+    else:
+        print(f"❌ Running in {conda_env} environment. Please activate vision-env:")
+        print("   conda activate vision-env")
+        return False
+
+def check_pytorch():
+    """Check PyTorch installation."""
+    try:
+        import torch
+        print(f"✅ PyTorch version: {torch.__version__}")
+        print(f"✅ CUDA available: {torch.cuda.is_available()}")
+        if torch.cuda.is_available():
+            print(f"✅ CUDA version: {torch.version.cuda}")
+        return True
+    except ImportError:
+        print("❌ PyTorch not found. Please install with:")
+        print("   pip install torch==2.6.0 torchvision==0.21.0 --index-url https://download.pytorch.org/whl/cu126")
+        return False
+
+def check_transformers():
+    """Check transformers installation."""
+    try:
+        import transformers
+        print(f"✅ Transformers version: {transformers.__version__}")
+        
+        # Check for specific classes
+        try:
+            from transformers import AutoModelForImageTextToText, AutoProcessor, AutoTokenizer
+            print("✅ AutoModelForImageTextToText available")
+            return True
+        except ImportError as e:
+            print(f"❌ AutoModelForImageTextToText not available: {e}")
+            print("   Please update transformers: pip install transformers>=4.46.0")
+            return False
+    except ImportError:
+        print("❌ Transformers not found. Please install with:")
+        print("   pip install transformers>=4.46.0")
+        return False
+
+def check_qwen_utils():
+    """Check qwen_vl_utils installation."""
+    try:
+        from qwen_vl_utils import process_vision_info
+        print("✅ qwen_vl_utils available")
+        return True
+    except ImportError:
+        print("❌ qwen_vl_utils not found. Please install with:")
+        print("   pip install qwen-vl-utils[decord]==0.0.8")
+        return False
+
+def check_other_deps():
+    """Check other important dependencies."""
+    deps = [
+        ('PIL', 'Pillow'),
+        ('numpy', 'numpy'),
+        ('matplotlib', 'matplotlib'),
+        ('cv2', 'opencv-python'),
+        ('accelerate', 'accelerate'),
+        ('bitsandbytes', 'bitsandbytes'),
+    ]
+    
+    all_good = True
+    for module, package in deps:
+        try:
+            __import__(module)
+            print(f"✅ {module} available")
+        except ImportError:
+            print(f"❌ {module} not found. Install with: pip install {package}")
+            all_good = False
+    
+    return all_good
+
+def main():
+    """Main check function."""
+    print("=" * 50)
+    print("Multi-Vision Toolkit Environment Check")
+    print("=" * 50)
+    
+    checks = [
+        ("Python Version", check_python_version),
+        ("Conda Environment", check_conda_env),
+        ("PyTorch", check_pytorch),
+        ("Transformers", check_transformers),
+        ("Qwen Utils", check_qwen_utils),
+        ("Other Dependencies", check_other_deps),
+    ]
+    
+    results = []
+    for name, check_func in checks:
+        print(f"\n{name}:")
+        print("-" * 20)
+        result = check_func()
+        results.append((name, result))
+    
+    print("\n" + "=" * 50)
+    print("Summary:")
+    print("=" * 50)
+    
+    all_passed = True
+    for name, result in results:
+        status = "✅ PASS" if result else "❌ FAIL"
+        print(f"{name}: {status}")
+        if not result:
+            all_passed = False
+    
+    if all_passed:
+        print("\n🎉 All checks passed! Your environment is ready.")
+    else:
+        print("\n⚠️  Some checks failed. Please fix the issues above.")
+        print("\nQuick fix steps:")
+        print("1. conda activate vision-env")
+        print("2. pip install -r requirements.txt")
+        print("3. pip install qwen-vl-utils[decord]==0.0.8")
+        print("4. ./clone_models.sh  # if you haven't downloaded models yet")
+    
+    return all_passed
+
+if __name__ == "__main__":
+    main()

--- a/models/qwen_model.py
+++ b/models/qwen_model.py
@@ -28,7 +28,7 @@ except ImportError:
     Image = None # type: ignore
 
 _QWEN_CLASS_AVAILABLE = False
-AutoModelForImageTextToText = None
+Qwen2_5_VLForConditionalGeneration = None
 AutoProcessor = None
 AutoTokenizer = None # type: ignore
 CLIPModel = None # type: ignore
@@ -37,7 +37,7 @@ process_vision_info_fn = None # type: ignore
 
 def safe_import_transformers():
     """Safely import transformers with flash attention guards."""
-    global _QWEN_CLASS_AVAILABLE, AutoModelForImageTextToText, AutoProcessor, AutoTokenizer
+    global _QWEN_CLASS_AVAILABLE, Qwen2_5_VLForConditionalGeneration, AutoProcessor, AutoTokenizer
     
     try:
         # Check for flash attention conflicts before importing
@@ -45,9 +45,9 @@ def safe_import_transformers():
         if importlib.util.find_spec("flash_attn"):
             logger.warning("Flash attention detected - may cause symbol conflicts, proceeding with caution")
         
-        from transformers import AutoModelForImageTextToText, AutoProcessor, AutoTokenizer
+        from transformers import Qwen2_5_VLForConditionalGeneration, AutoProcessor, AutoTokenizer
         _QWEN_CLASS_AVAILABLE = True
-        logger.info("Successfully imported AutoModelForImageTextToText, AutoProcessor, AutoTokenizer.")
+        logger.info("Successfully imported Qwen2_5_VLForConditionalGeneration, AutoProcessor, AutoTokenizer.")
         return True
         
     except ImportError as e:
@@ -59,7 +59,7 @@ def safe_import_transformers():
             os.environ["USE_FLASH_ATTENTION"] = "0"
             os.environ["FLASH_ATTN_DISABLE"] = "1"
             try:
-                from transformers import AutoModelForImageTextToText, AutoProcessor, AutoTokenizer
+                from transformers import Qwen2_5_VLForConditionalGeneration, AutoProcessor, AutoTokenizer
                 _QWEN_CLASS_AVAILABLE = True
                 logger.info("Successfully imported transformers without flash attention.")
                 return True
@@ -69,6 +69,8 @@ def safe_import_transformers():
                 return False
         else:
             logger.error(f"Failed to import Qwen classes from transformers: {e}")
+            logger.error("This may indicate the transformers version doesn't support Qwen2_5_VLForConditionalGeneration")
+            logger.error("Please update transformers: pip install git+https://github.com/huggingface/transformers.git")
             _QWEN_CLASS_AVAILABLE = False
             return False
             
@@ -220,7 +222,7 @@ class QwenModel(BaseVisionModel):
             try:
                 importlib.import_module(package)
                 if package == 'transformers' and not _QWEN_CLASS_AVAILABLE:
-                    missing_packages.append((package, f"{pip_name} (AutoModelForImageTextToText class not found. Ensure latest git version.)"))
+                    missing_packages.append((package, f"{pip_name} (Qwen2_5_VLForConditionalGeneration class not found. Ensure latest git version.)"))
             except ImportError:
                 missing_packages.append((package, pip_name))
         
@@ -472,7 +474,7 @@ class QwenCaptioner(BaseVisionModel):
             try:
                 importlib.import_module(package)
                 if package == 'transformers' and not _QWEN_CLASS_AVAILABLE:
-                    missing_packages.append((package, f"{pip_name} (AutoModelForImageTextToText class not found. Ensure latest git version.)"))
+                    missing_packages.append((package, f"{pip_name} (Qwen2_5_VLForConditionalGeneration class not found. Ensure latest git version.)"))
             except ImportError:
                 missing_packages.append((package, pip_name))
         
@@ -518,9 +520,9 @@ class QwenCaptioner(BaseVisionModel):
     def _setup_model(self) -> None:
         self._using_fallback = False
         try:
-            if not _QWEN_CLASS_AVAILABLE or AutoModelForImageTextToText is None:
-                logger.error("AutoModelForImageTextToText class not available. Falling back.")
-                self._load_clip_as_fallback(reason="AutoModelForImageTextToText class not found.")
+            if not _QWEN_CLASS_AVAILABLE or Qwen2_5_VLForConditionalGeneration is None:
+                logger.error("Qwen2_5_VLForConditionalGeneration class not available. Falling back.")
+                self._load_clip_as_fallback(reason="Qwen2_5_VLForConditionalGeneration class not found.")
                 return
 
             
@@ -545,7 +547,7 @@ class QwenCaptioner(BaseVisionModel):
             logger.info("Flash Attention disabled to prevent symbol conflicts - using eager attention for stability")
             model_kwargs["attn_implementation"] = "eager"
             
-            self.model = AutoModelForImageTextToText.from_pretrained(self.model_path, **model_kwargs)
+            self.model = Qwen2_5_VLForConditionalGeneration.from_pretrained(self.model_path, **model_kwargs)
             
             # Patch missing is_causal attribute for vision attention modules
             self._patch_vision_attention_is_causal()
@@ -567,9 +569,9 @@ class QwenCaptioner(BaseVisionModel):
         """Setup method specifically for QwenCaptioner with quantization support."""
         self._using_fallback = False
         try:
-            if not _QWEN_CLASS_AVAILABLE or AutoModelForImageTextToText is None:
-                logger.error("AutoModelForImageTextToText class not available. Falling back.")
-                self._load_clip_as_fallback(reason="AutoModelForImageTextToText class not found.")
+            if not _QWEN_CLASS_AVAILABLE or Qwen2_5_VLForConditionalGeneration is None:
+                logger.error("Qwen2_5_VLForConditionalGeneration class not available. Falling back.")
+                self._load_clip_as_fallback(reason="Qwen2_5_VLForConditionalGeneration class not found.")
                 return
 
             
@@ -658,7 +660,7 @@ class QwenCaptioner(BaseVisionModel):
             model_kwargs["attn_implementation"] = "eager"
             logger.info("Using eager attention for stability and compatibility (flash attention disabled)")
             
-            self.model = AutoModelForImageTextToText.from_pretrained(self.model_path, **model_kwargs)
+            self.model = Qwen2_5_VLForConditionalGeneration.from_pretrained(self.model_path, **model_kwargs)
             
             # Patch missing is_causal attribute for vision attention modules
             self._patch_vision_attention_is_causal()
@@ -1129,6 +1131,6 @@ class QwenCaptioner(BaseVisionModel):
     @classmethod
     def is_available(cls) -> bool:
         if not _QWEN_CLASS_AVAILABLE:
-            logger.warning("AutoModelForImageTextToText class not found. Qwen model not available.")
+            logger.warning("Qwen2_5_VLForConditionalGeneration class not found. Qwen model not available.")
             return False
         return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,10 @@ torch==2.6.0
 torchvision==0.21.0
 # torchaudio==2.6.0  # Only include if actually needed
 
-# Transformers - use stable version that supports Qwen2.5-VL
-transformers==4.46.3  # Latest stable with Qwen2.5-VL support
-# Alternative if 4.46.3 doesn't work:
-# transformers==4.45.2
+# Transformers - use git version that supports Qwen2.5-VL
+git+https://github.com/huggingface/transformers.git  # Latest with Qwen2.5-VL support
+# Alternative if git version doesn't work:
+# transformers==4.46.3
 
 # Core dependencies
 Pillow>=10.0.0


### PR DESCRIPTION
  model error handling

  - Fix CLIP fallback device mismatch error ("Expected cuda device, but got: cpu")
  - Update Qwen model to use Qwen2_5_VLForConditionalGeneration class
  - Add proper device handling for CLIP fallback tensors
  - Implement missing _analyze_with_clip method in base QwenModel class
  - Enhance error messages with clear dependency installation guidance
  - Update transformers dependency to git version for Qwen 2.5 VL support
  - Add comprehensive error handling for transformers version compatibility
  - Add environment checker script for debugging dependency issues

  Resolves device mismatch issues in CLIP fallback mode and ensures proper
  model loading with clear user guidance when dependencies are missing.